### PR TITLE
Feature/core

### DIFF
--- a/buildtagls.go
+++ b/buildtagls.go
@@ -1,6 +1,9 @@
 package buildtagls
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -14,5 +17,43 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
+	tags := map[string]bool{}
+
+	for _, f := range pass.Files {
+		for _, group := range f.Comments {
+			// A +build comment afer package declaration is not valid
+			if group.End()+1 >= f.Package {
+				continue
+			}
+
+			// Check comments before package declaration
+			for _, comment := range group.List {
+				// Skipping comments not containing +build
+				if !strings.Contains(comment.Text, "+build") {
+					continue
+				}
+
+				line := strings.TrimPrefix(comment.Text, "//")
+				line = strings.TrimSpace(line)
+				if strings.HasPrefix(line, "+build") {
+					regex := regexp.MustCompile(`[, ]+`)
+					toks := regex.Split(line, -1)
+					if toks[0] != "+build" {
+						continue
+					}
+
+					for _, tag := range toks[1:] {
+						tag := strings.TrimPrefix(tag, "!")
+						tags[tag] = true
+					}
+				}
+			}
+		}
+	}
+
+	for tag := range tags {
+		fmt.Println(tag)
+	}
+
 	return nil, nil
 }

--- a/testdata/src/a/enterprise.go
+++ b/testdata/src/a/enterprise.go
@@ -1,0 +1,23 @@
+// Program explanation
+// Author info, etc
+
+// +buildmiss
+// +build !pro,!enterprise
+
+// +build nonewline
+package main
+
+var _ = `
+// +build insidevar
+`
+
+/* Multiline comment
+ * +build multiline
+ */
+func init() {
+  features = append(
+    features,
+    "Enterprise Feature 1",
+    "Enterprise Feature 2",
+  )
+}

--- a/testdata/src/a/pro.go
+++ b/testdata/src/a/pro.go
@@ -1,0 +1,19 @@
+// +build !pro
+
+// comment +build
+
+/*
+ * Multiline comment
+ */
+
+package main
+
+// +build afterpackage
+
+func init() {
+  features = append(
+    features,
+    "Pro Feature 1", // Comment here
+    "Pro Feature 2",
+  )
+}


### PR DESCRIPTION
# やりたい事
パッケージのbuildタグ一覧を出力したい

## このPRの実装内容
- [x] コメントの取得
- [x] パッケージ宣言後のコメントを排除する処理
- [x] `+build`を含んだコメントのチェック処理
- [x] 正当なbuildタグを出力する

## 課題
`!tag`以外のbuildタグをソースコードに与えた場合，そのファイルがスキップされ，`*analysis.Pass`の`Files`フィールドに見つからなくなる．

### 具体例
`testdata/src/a`のパッケージには，`pro`と`enterprise`のbuildタグがある．現在は，pro.goには`// +build !pro`，enterprise.goには`// +build !pro,!enterprise`でbuildタグを記述している．しかし，pro.goには`// +build pro`，enterprise.goには`// +build pro,enterprise`でbuildタグを記述するのが理想．理想の記述仕方では，タグなしでmain.goしかビルドされないため，他のファイルが`*analysis.Pass`で拾えないことに困っている．
   | buildタグ  | ビルド時に含まれるソースコード ||
   | :---: | :---: |  :---: |
   |  | __現在__ | __理想__ |
   | タグなし | main.go, pro.go, enterprise.go  | main.go |
   | pro | main.go  | main.go, pro.go |
   | enterprise |  main.go, pro.go | main.go |
   | pro enterprise |  main.go |main.go, pro.go, enterprise.go |